### PR TITLE
Use timezone aware comparisons for cert validity

### DIFF
--- a/src/autograph_utils/__init__.py
+++ b/src/autograph_utils/__init__.py
@@ -332,15 +332,15 @@ class SignatureVerifier:
 
         now = _now()
         for cert in certs:
-            if cert.not_valid_before > cert.not_valid_after:
+            if cert.not_valid_before_utc > cert.not_valid_after_utc:
                 raise BadCertificate(
-                    f"not_before ({cert.not_valid_before}) after "
-                    f"not_after ({cert.not_valid_after})"
+                    f"not_before ({cert.not_valid_before_utc}) after "
+                    f"not_after ({cert.not_valid_after_utc})"
                 )
-            if now < cert.not_valid_before:
-                raise CertificateNotYetValid(cert.not_valid_before)
-            if now > cert.not_valid_after:
-                raise CertificateExpired(cert.not_valid_after)
+            if now < cert.not_valid_before_utc:
+                raise CertificateNotYetValid(cert.not_valid_before_utc)
+            if now > cert.not_valid_after_utc:
+                raise CertificateExpired(cert.not_valid_after_utc)
 
         # Verify chain of trust.
         chain = certs[::-1]

--- a/tests/test_autograph_utils.py
+++ b/tests/test_autograph_utils.py
@@ -4,6 +4,7 @@
 """Tests for `autograph_utils` package."""
 
 import datetime
+from datetime import timezone
 import os.path
 from unittest import mock
 
@@ -89,7 +90,7 @@ def cache():
 def now_fixed():
     with mock.patch("autograph_utils._now") as m:
         # A common static time used in a lot of tests.
-        m.return_value = datetime.datetime(2019, 10, 23, 16, 16, tzinfo=datetime.UTC)
+        m.return_value = datetime.datetime(2019, 10, 23, 16, 16, tzinfo=timezone.utc)
         # Yield the mock so someone can change the time if they want
         yield m
 
@@ -180,7 +181,7 @@ async def test_verify_signature_bad_numbers(aiohttp_session, mock_with_x5u, cach
 
 
 async def test_verify_x5u_expired(aiohttp_session, mock_with_x5u, cache, now_fixed):
-    now_fixed.return_value = datetime.datetime(2022, 10, 23, 16, 16, 16, tzinfo=datetime.UTC)
+    now_fixed.return_value = datetime.datetime(2022, 10, 23, 16, 16, 16, tzinfo=timezone.utc)
     s = SignatureVerifier(aiohttp_session, cache, DEV_ROOT_HASH)
     with pytest.raises(autograph_utils.CertificateExpired) as excinfo:
         await s.verify(SIGNED_DATA, SAMPLE_SIGNATURE, FAKE_CERT_URL)
@@ -189,7 +190,7 @@ async def test_verify_x5u_expired(aiohttp_session, mock_with_x5u, cache, now_fix
 
 
 async def test_verify_x5u_too_soon(aiohttp_session, mock_with_x5u, cache, now_fixed):
-    now_fixed.return_value = datetime.datetime(2010, 10, 23, 16, 16, 16, tzinfo=datetime.UTC)
+    now_fixed.return_value = datetime.datetime(2010, 10, 23, 16, 16, 16, tzinfo=timezone.utc)
     s = SignatureVerifier(aiohttp_session, cache, DEV_ROOT_HASH)
     with pytest.raises(autograph_utils.CertificateNotYetValid) as excinfo:
         await s.verify(SIGNED_DATA, SAMPLE_SIGNATURE, FAKE_CERT_URL)

--- a/tests/test_autograph_utils.py
+++ b/tests/test_autograph_utils.py
@@ -8,11 +8,14 @@ import os.path
 from unittest import mock
 
 import aiohttp
-import autograph_utils
 import cryptography.x509
 import pytest
 import pytest_asyncio
 from aioresponses import aioresponses
+from click.testing import CliRunner
+from cryptography.hazmat.backends import default_backend
+
+import autograph_utils
 from autograph_utils import (
     ExactMatch,
     MemoryCache,
@@ -20,8 +23,6 @@ from autograph_utils import (
     decode_mozilla_hash,
     main,
 )
-from click.testing import CliRunner
-from cryptography.hazmat.backends import default_backend
 
 
 TESTS_BASE = os.path.dirname(__file__)

--- a/tests/test_autograph_utils.py
+++ b/tests/test_autograph_utils.py
@@ -4,8 +4,8 @@
 """Tests for `autograph_utils` package."""
 
 import datetime
-from datetime import timezone
 import os.path
+from datetime import timezone
 from unittest import mock
 
 import aiohttp


### PR DESCRIPTION
This gets rid of some deprecation warnings from `cryptography`