### PR TITLE
Fix deprecated call to `utcnow()`

### DIFF
--- a/src/autograph_utils/__init__.py
+++ b/src/autograph_utils/__init__.py
@@ -11,7 +11,7 @@ import base64
 import binascii
 import re
 from abc import ABC
-from datetime import datetime
+from datetime import datetime, timezone
 
 import cryptography
 import ecdsa.util
@@ -508,4 +508,4 @@ def _now():
 
     :returns: naive datetime representing a UTC timestamp
     """
-    return datetime.utcnow()
+    return datetime.now(tz=timezone.utc)

--- a/tests/test_autograph_utils.py
+++ b/tests/test_autograph_utils.py
@@ -180,8 +180,7 @@ async def test_verify_signature_bad_numbers(aiohttp_session, mock_with_x5u, cach
         await s.verify(SIGNED_DATA, SAMPLE_SIGNATURE[:-4], FAKE_CERT_URL)
 
 
-async def test_verify_x5u_expired(aiohttp_session, mock_with_x5u, cache, now_fixed):
-    now_fixed.return_value = datetime.datetime(2022, 10, 23, 16, 16, 16, tzinfo=timezone.utc)
+async def test_verify_x5u_expired(aiohttp_session, mock_with_x5u, cache):
     s = SignatureVerifier(aiohttp_session, cache, DEV_ROOT_HASH)
     with pytest.raises(autograph_utils.CertificateExpired) as excinfo:
         await s.verify(SIGNED_DATA, SAMPLE_SIGNATURE, FAKE_CERT_URL)


### PR DESCRIPTION
Without this, the `_now()` returns a datetime without timezone, and breaks in the real world: https://github.com/mozilla-services/telescope/pull/1493 and https://github.com/mozilla/remote-settings/pull/667

The tests don't catch this because they mock `_now()` :/ 